### PR TITLE
If multiple entries are present, any check is good enough

### DIFF
--- a/src/main/scala/com/github/mpetruska/ukmodulo/ModulusCheck.scala
+++ b/src/main/scala/com/github/mpetruska/ukmodulo/ModulusCheck.scala
@@ -72,10 +72,10 @@ object ModulusCheck {
         Exception14.check(accountDigits, row.weights)
 
       case standardChecks if standardChecks.forall(_._1.isEmpty) =>
-        EitherChecks.all(
+        EitherChecks.any(
           standardChecks.map{
             case (_, row) => processStandard(accountDigits, row)
-          }: _*
+          }.toSeq
         )
 
       case _ =>

--- a/src/test/scala/com/github/mpetruska/ukmodulo/ModulusCheckSpec.scala
+++ b/src/test/scala/com/github/mpetruska/ukmodulo/ModulusCheckSpec.scala
@@ -55,7 +55,8 @@ class ModulusCheckSpec extends WordSpec with TableDrivenPropertyChecks with Matc
     ("560003",   "23354647",      false),
     ("308087",   "25337846",      false),
     ("308088",   "14457846",      true),
-    ("308088",   "24457846",      false)
+    ("308088",   "24457846",      false),
+    ("902338",   "44189808",      true)
   )
 
   "ModulusCheck" should {


### PR DESCRIPTION
Hi, found an issue where if the weight tables have multiple rows, the library was checking if all of them pass instead of allowing any one to pass. I have added the test case for a sample account number sort code which is valid.

I'm not a Scala dev, so if there is a better way to implement the fix, please feel free to change. 